### PR TITLE
macOS getting started readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Kamu is an application that focus on managing a physical library where you can a
 
 Here is a quick step-by-step minimal setup, to get the app up and running in your local workstation:
 
+### MacOS specific
+To install node.js and its package manager ```npm``` you can either download it from the [node.js homepage](https://nodejs.org/en/download/) or use a package manager like:
+- [homebrew](https://brew.sh)
+```shell
+brew install node
+```
+- [macports](https://www.macports.org/install.php)
+```shell
+port install nodejs
+```
+
+### Platform independent
 Create Python virtual enviroment:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -41,28 +41,6 @@ Install frontend dependencies using npm:
 npm install package.json
 ```
 
-**For setup local with authenticate with Okta Preview:**
-Use the "OKTA_METADATA_URL='url-of-okta-saml'" concatenating with the python's commands:
-
-```shell
-  Examples:  
-  OKTA_METADATA_URL='url-of-okta-saml' npm run-script start
-  OKTA_METADATA_URL='url-of-okta-saml' python manage.py migrate
-```
-
-Another way is to export the var and then execute the commands:
-
-```shell
-  export OKTA_METADATA_URL='url-of-okta-saml'
-  npm run-script start
-  python manage.py migrate
-```
-In case of need authenticate without Okta preview again, execute:
-
-```shell
-  unset OKTA_METADATA_URL
-```
-
 Create database tables:
 
 ```shell
@@ -91,6 +69,28 @@ npm run-script start
 ```
 
 Now just go to [http://localhost:8000](http://localhost:8000) in your browser :)
+
+**For setup local with authenticate with Okta Preview:**
+Use the "OKTA_METADATA_URL='url-of-okta-saml'" concatenating with the python's commands:
+
+```shell
+  Examples:
+  OKTA_METADATA_URL='url-of-okta-saml' npm run-script start
+  OKTA_METADATA_URL='url-of-okta-saml' python manage.py migrate
+```
+
+Another way is to export the var and then execute the commands:
+
+```shell
+  export OKTA_METADATA_URL='url-of-okta-saml'
+  npm run-script start
+  python manage.py migrate
+```
+In case of need authenticate without Okta preview again, execute:
+
+```shell
+  unset OKTA_METADATA_URL
+```
 
 ## Running and configuring cronjobs
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Install backend dependencies using pip:
 pip install -r requirements.txt
 ```
 
+Install frontend dependencies using npm:
+
+```shell
+npm install package.json
+```
+
 **For setup local with authenticate with Okta Preview:**
 Use the "OKTA_METADATA_URL='url-of-okta-saml'" concatenating with the python's commands:
 


### PR DESCRIPTION
added macOS specific install instruction for node.js and moved "okra preview" block to the end of the instructions as optional