### PR TITLE
Added node docker container build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  app:
+    image: kamu
+    container_name: kamu
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    volumes:
+      - .:/home/node/kamu
+    ports:
+      - 8000:8000
+      - 3000:3000
+    tty: true
+    environment:
+      NODE_ENV: local
+      CONTAINER_ROLE: app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:10.8.0
+
+RUN wget https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz && \
+    tar xJf Python-3.6.3.tar.xz && \
+    cd Python-3.6.3 && \
+    ./configure && \
+    make && \
+    make install
+
+COPY . /home/node/kamu
+WORKDIR /home/node/kamu
+
+RUN python3 -m venv kamu &&  \
+    cp /usr/local/bin/python3.6 /usr/local/bin/python && \
+    chmod +x kamu/bin/activate && \
+    /bin/bash -c "source kamu/bin/activate" && \
+    pip3.6 install -r requirements.txt && \
+    npm install package.json && \
+    python manage.py migrate && \
+    python manage.py loaddata dump_data/*.json
+
+EXPOSE 8000
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Created docker container build for the app re the #46 request.

One command is not executed in the build:
-`python manage.py createsuperuser` because it is interactive, and if there is a way to execute this command in a build please let me know.

Build and start the container in the foreground
`docker-compose up`

Build and start the container in the background
`docker-compose up -d`

You can notice that this build has
- node 10.8.0
- python 3.6
- pip 3.6
- yarn 1.12.0 (maybe you don't need that at all)

I have to say that I was not able to get app visible on the http://localhost:8000 
Maybe you can review and help me to spot the issue. I will gladly solve the issue.

