### PR TITLE
Update psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 packaging==16.8
 Paste==2.0.3
-psycopg2==2.7.3.2
+psycopg2==2.7.5
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodomex==3.4.7


### PR DESCRIPTION
I went through the instructions on README using Antergos (Arch linux son's). This PR closes https://github.com/ayr-ton/kamu/issues/40. The only issue I got into was the psycopg2 version (error: `Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-z94zs85a/psycopg2/`).

A part from that everything worked fine. :+1: 