### PR TITLE
Search book by isbn

### DIFF
--- a/books/admin.py
+++ b/books/admin.py
@@ -1,6 +1,7 @@
-from django import forms
 from django.contrib import admin
+from django.urls import path
 
+from books import views
 from .models import *
 
 
@@ -24,6 +25,16 @@ class BookAdmin(admin.ModelAdmin):
     list_per_page = 20
     search_fields = ['title', 'author', 'isbn']
 
+    def get_urls(self):
+        urls = super().get_urls()
+
+        info = self.model._meta.app_label, self.model._meta.model_name
+
+        my_urls = [
+            path('isbn/', views.IsbnFormView.as_view(),  name='%s_%s_isbn' % info),
+        ]
+
+        return my_urls + urls
 
 class BookCopyAdmin(admin.ModelAdmin):
     list_display = ['id', 'book', 'library', 'user']

--- a/books/forms.py
+++ b/books/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class IsbnForm(forms.Form):
+    isbn = forms.CharField(max_length=13, required=True)

--- a/books/google.py
+++ b/books/google.py
@@ -1,0 +1,50 @@
+import requests
+
+
+class ResponseParser(object):
+    def __init__(self, isbn, content):
+        self.isbn = isbn
+        self.content = content
+
+    def extract_book(self):
+        if self.content['totalItems'] == 0:
+            return {}
+
+        # Hit the following URL to get a sample response:
+        #   https://www.googleapis.com/books/v1/volumes?q=isbn:9780133065268
+
+        # TODO: show an intermediate page with all the items and prompt user to select the one which
+        #   they would like to use as a template for adding a new book to the library.
+        #   For now, we select the last book in the list.
+
+        return self._build(self.content['items'][-1])
+
+    def _build(self, data):
+        volume_info = data['volumeInfo']
+
+        return {
+            'isbn': self.isbn,
+            'author': ', '.join(volume_info['authors']),
+            'description': volume_info['description'],
+            'image_url': volume_info['imageLinks']['thumbnail'],
+            'number_of_pages': volume_info['pageCount'],
+            'publication_date': volume_info['publishedDate'],
+            'publisher': volume_info['publisher'],
+            'subtitle': volume_info['subtitle'],
+            'title': volume_info['title']
+        }
+
+
+class BookFinder(object):
+    GOOGLE_BOOKS_URL = 'https://www.googleapis.com/books/v1/volumes'
+    OK = 200
+
+    @classmethod
+    def fetch(cls, isbn):
+        url = "{}?q=isbn:{}".format(cls.GOOGLE_BOOKS_URL, isbn)
+        response = requests.get(url)
+
+        if response.status_code != cls.OK:
+            return {}
+
+        return ResponseParser(isbn, response.json()).extract_book()

--- a/books/templates/isbn.html
+++ b/books/templates/isbn.html
@@ -1,0 +1,25 @@
+{% extends "admin/app_index.html" %}
+{% load render_bundle from webpack_loader %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header }}</a></h1>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>Find book by ISBN</h1>
+
+  <form action="{{ books_isbn_url }}" method="post">
+      {% csrf_token %}
+      <table>
+        <tbody>
+            {{ form.as_table }}
+            <tr>
+                <th></th>
+                <td style="text-align:right"><input type="submit" value="Submit"></td>
+            </tr>
+        </tbody>
+      </table>
+  </form>
+</div>
+{% endblock %}

--- a/books/test/test_forms.py
+++ b/books/test/test_forms.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from books.forms import IsbnForm
+
+# FORMS
+class IsbnFormTest(TestCase):
+    def test_valid_data(self):
+        form = IsbnForm({'isbn': '9780133065268'})
+
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_data(self):
+        form = IsbnForm()
+
+        self.assertFalse(form.is_valid())

--- a/books/test/test_google.py
+++ b/books/test/test_google.py
@@ -1,0 +1,143 @@
+from unittest import mock, TestCase
+
+import httpretty
+
+from books.google import BookFinder, ResponseParser
+
+
+class BookFinderTest(TestCase):
+    @httpretty.activate
+    @mock.patch('books.google.ResponseParser')
+    def test_should_parse_response_when_google_api_call_succeeds(self, mockResponseParser):
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://www.googleapis.com/books/v1/volumes?q=isbn:9780133065268",
+            body='{"kind": "books#volumes", "totalItems": 0}',
+            status=200)
+
+        BookFinder.fetch('9780133065268')
+
+        mockResponseParser.assert_called_with('9780133065268', {"kind": "books#volumes", "totalItems": 0})
+
+    @httpretty.activate
+    @mock.patch('books.google.ResponseParser')
+    def test_should_parse_response_when_google_api_call_fails(self, mockResponseParser):
+        httpretty.register_uri(
+            httpretty.GET,
+            "https://www.googleapis.com/books/v1/volumes?q=isbn:9780133065268",
+            body='{"kind": "books#volumes", "totalItems": 0}',
+            status=404)
+
+        book = BookFinder.fetch('9780133065268')
+
+        self.assertDictEqual(book, {})
+
+        mockResponseParser.assert_not_called()
+
+
+class ResponseParserTest(TestCase):
+    def test_should_return_empty_dict_when_there_are_no_items_in_response(self):
+        content = {"kind": "books#volumes", "totalItems": 0}
+        book = ResponseParser('9780133065268', content).extract_book()
+
+        self.assertDictEqual(book, {})
+
+    def test_should_return_the_only_item_when_only_one_item_exists(self):
+        content = {
+            "kind": "books#volumes",
+            "totalItems": 1,
+            "items": [
+                {
+                    "volumeInfo": {
+                        "title": "Refactoring",
+                        "subtitle": "Improving the Design of Existing Code",
+                        "authors": [
+                            "Martin Fowler",
+                            "Kent Beck",
+                            "John Brant",
+                            "William Opdyke",
+                            "Don Roberts"
+                        ],
+                        "publisher": "Addison-Wesley",
+                        "publishedDate": "2012-03-09",
+                        "description": "As the application of object technology--particularly bla bla bla.",
+                        "pageCount": 455,
+                        "imageLinks": {
+                            "thumbnail": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                        }
+                    }
+                }
+            ]
+        }
+
+        book = ResponseParser('9780133065268', content).extract_book()
+
+        self.assertDictEqual(book, {
+            "author": "Martin Fowler, Kent Beck, John Brant, William Opdyke, Don Roberts",
+            "description": "As the application of object technology--particularly bla bla bla.",
+            "image_url": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
+            "isbn": "9780133065268",
+            "number_of_pages": 455,
+            "publication_date": "2012-03-09",
+            "publisher": "Addison-Wesley",
+            "subtitle": "Improving the Design of Existing Code",
+            "title": "Refactoring"
+        })
+
+    def test_should_return_the_last_item_when_more_than_one_item_exist(self):
+        content = {
+            "kind": "books#volumes",
+            "totalItems": 2,
+            "items": [
+                {
+                    "volumeInfo": {
+                        "title": "Refactoring",
+                        "subtitle": "Improving the Design of Existing Code",
+                        "authors": [
+                            "Martin Fowler",
+                            "Kent Beck",
+                            "John Brant",
+                            "William Opdyke",
+                            "Don Roberts"
+                        ],
+                        "publisher": "Addison-Wesley",
+                        "publishedDate": "2012-03-09",
+                        "description": "As the application of object technology--particularly bla bla bla.",
+                        "pageCount": 455,
+                        "imageLinks": {
+                            "thumbnail": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                        }
+                    }
+                },
+                {
+                    "volumeInfo": {
+                        "title": "Refactoring II",
+                        "subtitle": "Improving the Design of Existing Code the New Way",
+                        "authors": [
+                            "Martin Fowler"
+                        ],
+                        "publisher": "Addison-Wesley",
+                        "publishedDate": "2018-12-09",
+                        "description": "Each refactoring step is simple--seemingly too simple to be worth doing.",
+                        "pageCount": 455,
+                        "imageLinks": {
+                            "thumbnail": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                        }
+                    }
+                }
+            ]
+        }
+
+        book = ResponseParser('9780133065268', content).extract_book()
+
+        self.assertDictEqual(book, {
+            "author": "Martin Fowler",
+            "description": "Each refactoring step is simple--seemingly too simple to be worth doing.",
+            "image_url": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
+            "isbn": "9780133065268",
+            "number_of_pages": 455,
+            "publication_date": "2018-12-09",
+            "publisher": "Addison-Wesley",
+            "subtitle": "Improving the Design of Existing Code the New Way",
+            "title": "Refactoring II"
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ drf-url-filters==0.5.1
 flake8==3.5.0
 future==0.16.0
 gunicorn==19.7.1
+httpretty==0.9.6
 idna==2.6
 isort==4.2.15
 lazy-object-proxy==1.3.1


### PR DESCRIPTION
Fixes #26 

This PR uses the Google Books API to search and prepopulate new book form with details retrieved using the ISBN provided by the user.

## How it works

- When user logs into the application, s/he provides an ISBN and submits the form. 
- The solution performs a lookup based on the ISB provided and loads the Add Book page with the details of the book pre-populated.
- User clicks on the Save button to save book information as-as or modifies book information before saving.

## Screenshots

<img width="1680" alt="screen shot 2018-12-27 at 4 40 20 pm" src="https://user-images.githubusercontent.com/3480287/50496554-6a356600-09f6-11e9-8914-9da9c73c11b9.png">
<img width="1680" alt="screen shot 2018-12-27 at 4 40 31 pm" src="https://user-images.githubusercontent.com/3480287/50496558-6e618380-09f6-11e9-9963-3db7facf8457.png">

## Challenges

Django's Admin site framework is quite inflexible and has little room for customization if the object being manipulated is not a model - which is the case for this scenario. The closest 
I could do to make the form look generic was to inherit the `admin/app_index.html` template in the isbn form template.

Due to the same issue of inflexibility, I could find nowhere on the Admin Dashboard to place a button to perform this particular action, ATM users will simply have to get there with the URL `admin/books/book/isbn`. Any knowledge on how to fix this is welcome.