### PR TITLE
Fix HTTP 500 error when adding books

### DIFF
--- a/books/google.py
+++ b/books/google.py
@@ -31,7 +31,7 @@ class ResponseParser(object):
             'title': ''
         }
 
-        volume_info = data['volumeInfo']
+        volume_info = {**volume_info, **data['volumeInfo']}
 
         return {
             'isbn': self.isbn,

--- a/books/google.py
+++ b/books/google.py
@@ -28,7 +28,8 @@ class ResponseParser(object):
             'pageCount': '',
             'publishedDate': '',
             'publisher': '',
-            'title': ''
+            'title': '',
+            'subtitle': ''
         }
 
         volume_info = {**volume_info, **data['volumeInfo']}

--- a/books/test/test_google.py
+++ b/books/test/test_google.py
@@ -141,3 +141,38 @@ class ResponseParserTest(TestCase):
             "subtitle": "Improving the Design of Existing Code the New Way",
             "title": "Refactoring II"
         })
+
+    def test_should_not_raise_exception_when_fields_are_missing(self):
+        # content without authors and description
+        content = {
+            "kind": "books#volumes",
+            "totalItems": 2,
+            "items": [
+                {
+                    "volumeInfo": {
+                        "title": "Refactoring II",
+                        "subtitle": "Improving the Design of Existing Code the New Way",
+                        "publisher": "Addison-Wesley",
+                        "publishedDate": "2018-12-09",
+                        "pageCount": 455,
+                        "imageLinks": {
+                            "thumbnail": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                        }
+                    }
+                }
+            ]
+        }
+
+        book = ResponseParser('9780133065268', content).extract_book()
+
+        self.assertDictEqual(book, {
+            "author": "",
+            "description": "",
+            "image_url": "http://books.google.com/books/content?id=HmrDHwgkbPsC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api",
+            "isbn": "9780133065268",
+            "number_of_pages": 455,
+            "publication_date": "2018-12-09",
+            "publisher": "Addison-Wesley",
+            "subtitle": "Improving the Design of Existing Code the New Way",
+            "title": "Refactoring II"
+        })

--- a/books/test/test_google.py
+++ b/books/test/test_google.py
@@ -143,7 +143,7 @@ class ResponseParserTest(TestCase):
         })
 
     def test_should_not_raise_exception_when_fields_are_missing(self):
-        # content without authors and description
+        # content without subtitle, authors and description
         content = {
             "kind": "books#volumes",
             "totalItems": 2,
@@ -151,7 +151,6 @@ class ResponseParserTest(TestCase):
                 {
                     "volumeInfo": {
                         "title": "Refactoring II",
-                        "subtitle": "Improving the Design of Existing Code the New Way",
                         "publisher": "Addison-Wesley",
                         "publishedDate": "2018-12-09",
                         "pageCount": 455,
@@ -173,6 +172,6 @@ class ResponseParserTest(TestCase):
             "number_of_pages": 455,
             "publication_date": "2018-12-09",
             "publisher": "Addison-Wesley",
-            "subtitle": "Improving the Design of Existing Code the New Way",
+            "subtitle": "",
             "title": "Refactoring II"
         })


### PR DESCRIPTION
There are times that the Google api returns a response with missing fields (mostly the `subtitle` field as not all books have a subtitle) that we rely on to create a new book. When such cases are encountered, the app renders an HTTP 500 page.

This PR ensures that these fields are initialized to empty values when such situations arise so users do not receive an HTTP 500 error.