### PR TITLE
Reduce generated bundle size

### DIFF
--- a/assets/src/Header.js
+++ b/assets/src/Header.js
@@ -2,8 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import AppBar from "@material-ui/core/AppBar";
 import IconButton from "@material-ui/core/IconButton";
+import Toolbar from '@material-ui/core/Toolbar';
+import Icon from '@material-ui/core/Icon';
+import Badge from '@material-ui/core/Badge';
 import { withRouter } from 'react-router';
-import { Toolbar, Icon, Badge } from "@material-ui/core";
 import { clearRegion, getRegion } from './services/ProfileService';
 import { HOME_URL, ADMIN_URL, MY_BOOKS_URL, ADD_BOOK_URL, LIBRARY_URL_PREFIX } from './utils/constants';
 

--- a/assets/src/libraries/BookDetail.js
+++ b/assets/src/libraries/BookDetail.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
-import { IconButton, Dialog, Avatar, DialogContent, DialogActions } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import Dialog from '@material-ui/core/Dialog';
+import Avatar from '@material-ui/core/Avatar';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
 import '../../css/ModalBook.css';
 import moment from 'moment';
 import Clear from '@material-ui/icons/Clear';

--- a/assets/src/libraries/Library.js
+++ b/assets/src/libraries/Library.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { CircularProgress } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import InfiniteScroll from 'react-infinite-scroller';
 import PropTypes from 'prop-types';
 import { getBooksByPage } from '../services/BookService';

--- a/assets/src/utils/filters/SearchBar.test.js
+++ b/assets/src/utils/filters/SearchBar.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import SearchBar from './SearchBar'
 import {shallow} from 'enzyme';
 import Close from '@material-ui/icons/Close';
-import { TextField } from '@material-ui/core';
+import TextField from '@material-ui/core/TextField';
 
 describe('SearchBar', () => {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
       }),
+      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     ],
 
     module: {


### PR DESCRIPTION
Refactor some imports from Material UI and ignore Moment.js's locales (which we don't use) when building.

**Comparing with master** (`npm run build`)

**Before optimizations:**
  app-aef97bd1757f032f85e1.js (568 KiB)
  home-aef97bd1757f032f85e1.js (260 KiB)
  libraries-aef97bd1757f032f85e1.js (823 KiB)
  mybooks-aef97bd1757f032f85e1.js (814 KiB)

**After optimizations:**
  app-4a4882eb183e927f973b.js (269 KiB)
  home-4a4882eb183e927f973b.js (259 KiB)
  libraries-4a4882eb183e927f973b.js (439 KiB)
  mybooks-4a4882eb183e927f973b.js (370 KiB)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/92)
<!-- Reviewable:end -->
