### PR TITLE
Return available book action (borrow/return/etc) via API

### DIFF
--- a/assets/src/components/books/Book.jsx
+++ b/assets/src/components/books/Book.jsx
@@ -25,9 +25,7 @@ export default class Book extends Component {
     this.onMouseOver = this.onMouseOver.bind(this);
     this.onMouseOut = this.onMouseOut.bind(this);
     this.actionButtons = this.actionButtons.bind(this);
-    this.borrow = this.borrow.bind(this);
-    this.return = this.return.bind(this);
-    this.waitlist = this.waitlist.bind(this);
+    this.performAction = this.performAction.bind(this);
     this.changeOpenStatus = this.changeOpenStatus.bind(this);
   }
 
@@ -35,24 +33,11 @@ export default class Book extends Component {
 
   onMouseOut() { this.setState({ zDepth: 1 }); }
 
-  borrow() {
-    borrowCopy(this.props.book).then((response) => {
+  performAction(action, eventCategory) {
+    const { book, library } = this.props;
+    return action(book, library).then((response) => {
       this.setState({ action: response.action });
-      window.ga('send', 'event', 'Borrow', this.props.book.title, this.props.library);
-    });
-  }
-
-  return() {
-    returnBook(this.props.book).then((response) => {
-      this.setState({ action: response.action });
-      window.ga('send', 'event', 'Return', this.props.book.title, this.props.library);
-    });
-  }
-
-  waitlist() {
-    joinWaitlist(this.props.library, this.props.book).then((response) => {
-      this.setState({ action: response.action });
-      window.ga('send', 'event', 'JoinWaitlist', this.props.book.title, this.props.library);
+      window.ga('send', 'event', eventCategory, this.props.book.title, this.props.library);
     });
   }
 
@@ -60,12 +45,12 @@ export default class Book extends Component {
     if (!this.state.action) return null;
     switch (this.state.action.type) {
       case BORROW_BOOK_ACTION:
-        return <Button className="btn-borrow" onClick={this.borrow}>Borrow</Button>;
+        return <Button onClick={() => this.performAction(borrowCopy, 'Borrow')}>Borrow</Button>;
       case RETURN_BOOK_ACTION:
-        return <Button className="btn-return" onClick={this.return}>Return</Button>;
+        return <Button onClick={() => this.performAction(returnBook, 'Return')}>Return</Button>;
       case JOIN_WAITLIST_BOOK_ACTION:
         return isWaitlistFeatureActive()
-          ? <Button className="btn-waitlist" onClick={this.waitlist}>Join the waitlist</Button>
+          ? <Button onClick={() => this.performAction(joinWaitlist, 'JoinWaitlist')}>Join the waitlist</Button>
           : null;
       default:
         return null;

--- a/assets/src/components/books/Book.jsx
+++ b/assets/src/components/books/Book.jsx
@@ -50,8 +50,7 @@ export default class Book extends Component {
         return <Button onClick={() => this.performAction(returnBook, 'Return')}>Return</Button>;
       case JOIN_WAITLIST_BOOK_ACTION:
         return isWaitlistFeatureActive()
-          ? <Button onClick={() => this.performAction(joinWaitlist, 'JoinWaitlist')}>Join the waitlist</Button>
-          : null;
+          && <Button onClick={() => this.performAction(joinWaitlist, 'JoinWaitlist')}>Join the waitlist</Button>;
       default:
         return null;
     }

--- a/assets/src/components/books/Book.test.jsx
+++ b/assets/src/components/books/Book.test.jsx
@@ -10,7 +10,7 @@ import {
   someBookWithACopyFromMe,
   someBookThatCanBeAddedToWaitlist,
   borrowAction,
-  returnAction
+  returnAction,
 } from '../../../test/booksHelper';
 import { borrowCopy, returnBook, joinWaitlist } from '../../services/BookService';
 

--- a/assets/src/components/books/Book.test.jsx
+++ b/assets/src/components/books/Book.test.jsx
@@ -9,6 +9,8 @@ import {
   someBookWithNoAvailableCopies,
   someBookWithACopyFromMe,
   someBookThatCanBeAddedToWaitlist,
+  borrowAction,
+  returnAction
 } from '../../../test/booksHelper';
 import { borrowCopy, returnBook, joinWaitlist } from '../../services/BookService';
 
@@ -42,12 +44,7 @@ const createComponent = (book) => shallow(<Book book={book} library="bh" />);
 
 describe('Book', () => {
   beforeEach(() => {
-    borrowCopy.mockResolvedValue();
-    returnBook.mockResolvedValue();
-    joinWaitlist.mockResolvedValue();
-
     global.currentUser = currentUser;
-
     global.window.ga = () => { };
   });
 
@@ -59,14 +56,15 @@ describe('Book', () => {
     expect(bookComponent.find('.book-cover').props().style.backgroundImage).toEqual(`url('${book.image_url}')`);
   });
 
-  it('shows the borrow button when the book has available copies', () => {
+  it('shows the borrow button when the book has a borrow action', () => {
     const book = someBookWithAvailableCopies();
     const bookComponent = createComponent(book);
 
     expect(bookComponent).toHaveBorrowButton();
   });
 
-  it('shows the return button when clicking borrow', async () => {
+  it('shows the return button when clicking borrow and API sends return action', async () => {
+    borrowCopy.mockResolvedValue({ action: returnAction });
     const book = someBookWithAvailableCopies();
     const bookComponent = createComponent(book);
 
@@ -84,24 +82,15 @@ describe('Book', () => {
     expect(borrowCopy).toHaveBeenCalledWith(book);
   });
 
-  it('shows the return button when the book is borrowed by me', () => {
+  it('shows the return button when the book has a return action', () => {
     const book = someBookWithACopyFromMe();
     const bookComponent = createComponent(book);
 
     expect(bookComponent).toHaveReturnButton();
   });
 
-  it('shows the return button when the book is borrowed by me but still has available copies', () => {
-    const book = someBook([
-      { id: 1, user: currentUser },
-      { id: 2, user: null },
-    ]);
-    const bookComponent = createComponent(book);
-
-    expect(bookComponent).toHaveReturnButton();
-  });
-
-  it('shows the borrow button when clicking return', async () => {
+  it('shows the borrow button when clicking return and API sends borrow action', async () => {
+    returnBook.mockResolvedValue({ action: borrowAction });
     const book = someBookWithACopyFromMe();
     const bookComponent = createComponent(book);
 
@@ -119,6 +108,13 @@ describe('Book', () => {
     expect(returnBook).toHaveBeenCalledWith(book);
   });
 
+  it('has no action button when the book has no action', () => {
+    const book = someBook([], [], null);
+    const bookComponent = createComponent(book);
+
+    expect(bookComponent.find(Button).exists()).toBeFalsy();
+  });
+
   describe('if waitlist feature is enabled', () => {
     beforeAll(() => {
       window.history.pushState({}, 'Testing with Waitlist Enabled', '/?waitlist=active');
@@ -128,18 +124,18 @@ describe('Book', () => {
       const book = someBookThatCanBeAddedToWaitlist();
       const bookComponent = createComponent(book);
 
-      expect(bookComponent.state('canBeAddedToWaitlist')).toBeTruthy();
       expect(bookComponent).toHaveJoinWaitlistButton();
     });
 
     it('calls the joinWaitlist method when clicking on the join the waitlist button', async () => {
+      joinWaitlist.mockResolvedValue({ action: null });
       const book = someBookThatCanBeAddedToWaitlist();
       const bookComponent = createComponent(book);
 
       await bookComponent.find(Button).simulate('click');
 
       expect(joinWaitlist).toHaveBeenCalledWith('bh', book);
-      expect(bookComponent.state('canBeAddedToWaitlist')).toBeFalsy();
+      expect(bookComponent).not.toHaveJoinWaitlistButton();
     });
   });
 

--- a/assets/src/components/books/Book.test.jsx
+++ b/assets/src/components/books/Book.test.jsx
@@ -18,23 +18,25 @@ jest.mock('../../services/BookService');
 
 expect.extend({
   toHaveBorrowButton(received) {
-    const pass = received.find(Button).exists()
-            && received.find(Button).hasClass('btn-borrow')
-            && !received.find(Button).hasClass('btn-return');
+    const button = received.find(Button);
+    const pass = button.exists()
+          && button.children().text() === 'Borrow'
+          && button.length === 1;
     return { pass, message: () => 'expected component to have a borrow button' };
   },
 
   toHaveReturnButton(received) {
-    const pass = received.find(Button).exists()
-            && !received.find(Button).hasClass('btn-borrow')
-            && received.find(Button).hasClass('btn-return');
+    const button = received.find(Button);
+    const pass = button.exists()
+          && button.children().text() === 'Return'
+          && button.length === 1;
     return { pass, message: () => 'expected component to have a return button' };
   },
 
   toHaveJoinWaitlistButton(received) {
     const button = received.find(Button);
     const pass = button.exists()
-          && button.hasClass('btn-waitlist')
+          && button.children().text() === 'Join the waitlist'
           && button.length === 1;
     return { pass, message: () => 'expected component to have a waitlist button' };
   },
@@ -79,7 +81,7 @@ describe('Book', () => {
 
     await bookComponent.find(Button).simulate('click');
 
-    expect(borrowCopy).toHaveBeenCalledWith(book);
+    expect(borrowCopy).toHaveBeenCalledWith(book, 'bh');
   });
 
   it('shows the return button when the book has a return action', () => {
@@ -105,7 +107,7 @@ describe('Book', () => {
 
     await bookComponent.find(Button).simulate('click');
 
-    expect(returnBook).toHaveBeenCalledWith(book);
+    expect(returnBook).toHaveBeenCalledWith(book, 'bh');
   });
 
   it('has no action button when the book has no action', () => {
@@ -134,7 +136,7 @@ describe('Book', () => {
 
       await bookComponent.find(Button).simulate('click');
 
-      expect(joinWaitlist).toHaveBeenCalledWith('bh', book);
+      expect(joinWaitlist).toHaveBeenCalledWith(book, 'bh');
       expect(bookComponent).not.toHaveJoinWaitlistButton();
     });
   });

--- a/assets/src/models/Book.js
+++ b/assets/src/models/Book.js
@@ -1,8 +1,4 @@
 export default class Book {
-  isAvailable() {
-    return this.getAvailableCopyID() != null;
-  }
-
   getAvailableCopyID() {
     for (const copy of this.copies) {
       if (copy.user === null) return copy.id;
@@ -15,23 +11,11 @@ export default class Book {
     return this.copies.filter((copy) => copy.user === null).length;
   }
 
-  belongsToUser() {
-    return this.getBorrowedCopyID() != null;
-  }
-
   getBorrowedCopyID() {
     for (const copy of this.copies) {
       if (copy.user && copy.user.username === currentUser.username) return copy.id;
     }
 
     return null;
-  }
-
-  isUserInWaitlist() {
-    return this.waitlist_users.filter((user) => user.username === currentUser.username).length > 0;
-  }
-
-  canBeAddedToWaitlist() {
-    return !this.isAvailable() && !this.isUserInWaitlist();
   }
 }

--- a/assets/src/models/Book.test.js
+++ b/assets/src/models/Book.test.js
@@ -1,31 +1,7 @@
-import {
-  someBook,
-  someBookWithAvailableCopies,
-  someBookWithNoAvailableCopies,
-} from '../../test/booksHelper';
+import { someBook } from '../../test/booksHelper';
 
 describe('Book model', () => {
   describe('checking the book availability', () => {
-    it('should return true when the book has one copy without a user', () => {
-      const book = someBook([{ id: 1, user: null }]);
-      expect(book.isAvailable()).toBeTruthy();
-    });
-
-    it('should return true when the book has at least one copy without a user', () => {
-      const book = someBook([{ id: 2, user: {} }, { id: 3, user: null }]);
-      expect(book.isAvailable()).toBeTruthy();
-    });
-
-    it('should return false when the book does not have a copy without a user', () => {
-      const book = someBook([{ id: 2, user: {} }]);
-      expect(book.isAvailable()).toBeFalsy();
-    });
-
-    it('should return false when all of the copies without a user', () => {
-      const book = someBook([{ id: 5, user: {} }, { id: 6, user: {} }]);
-      expect(book.isAvailable()).toBeFalsy();
-    });
-
     it('should return the first available book copy id without a user', () => {
       const book = someBook([{ id: 2, user: {} }, { id: 3, user: null }]);
       expect(book.getAvailableCopyID()).toEqual(3);
@@ -50,26 +26,6 @@ describe('Book model', () => {
   describe('checking if the user owns a copy of the book', () => {
     global.currentUser = { username: 1 };
 
-    it('should return true if the book has only one copy that belongs to the user', () => {
-      const book = someBook([{ id: 1, user: global.currentUser }]);
-      expect(book.belongsToUser()).toBeTruthy();
-    });
-
-    it('should return true if the book has at least one copy that belongs to the user', () => {
-      const book = someBook([{ id: 2, user: global.currentUser }, { id: 3, user: null }]);
-      expect(book.belongsToUser()).toBeTruthy();
-    });
-
-    it('should return false if none of the copies belongs to the user', () => {
-      const book = someBook([{ id: 4, user: { username: 2 } }]);
-      expect(book.belongsToUser()).toBeFalsy();
-    });
-
-    it('should return false if the book has no copies', () => {
-      const book = someBook([]);
-      expect(book.belongsToUser()).toBeFalsy();
-    });
-
     it('should return the id of the copy that belongs to the user when it has one copy', () => {
       const book = someBook([{ id: 1, user: global.currentUser }]);
       expect(book.getBorrowedCopyID()).toEqual(1);
@@ -83,40 +39,6 @@ describe('Book model', () => {
     it('should return null if the book does not have a copy that belongs to the user', () => {
       const book = someBook([{ id: 4, user: { username: 2 } }]);
       expect(book.getBorrowedCopyID()).toBeNull();
-    });
-  });
-
-  describe('checking if user has a book in her waitlist', () => {
-    global.currentUser = { username: 1 };
-
-    it('should return false if the user is not in waitlist_users list of the book', () => {
-      const book = someBook();
-      expect(book.isUserInWaitlist()).toBeFalsy();
-    });
-
-    it('should return true if the user is in waitlist_users list of the book', () => {
-      const book = someBook([], [{ username: 1 }]);
-      expect(book.isUserInWaitlist()).toBeTruthy();
-    });
-  });
-
-  describe('checking if user can add book to waitlist', () => {
-    global.currentUser = { username: 1 };
-
-    it('should return false if the book is available', () => {
-      const book = someBookWithAvailableCopies();
-      expect(book.canBeAddedToWaitlist()).toBeFalsy();
-    });
-
-    it('should return false if the book is not available, but the user is already in the waitlist', () => {
-      const book = someBookWithNoAvailableCopies();
-      book.waitlist_users = [{ username: 1 }];
-      expect(book.canBeAddedToWaitlist()).toBeFalsy();
-    });
-
-    it('should return true if the book is not available and the user is not in the waitlist yet', () => {
-      const book = someBookWithNoAvailableCopies();
-      expect(book.canBeAddedToWaitlist()).toBeTruthy();
     });
   });
 });

--- a/assets/src/services/BookService.js
+++ b/assets/src/services/BookService.js
@@ -34,22 +34,22 @@ export const getBooksByPage = (librarySlug, page, filter = '') => fetchFromAPI(`
 
 export const getMyBooks = () => fetchFromAPI('/profile/books').then((data) => formatBooksRequest(data));
 
-export const borrowCopy = (book) => {
+export const borrowCopy = async (book) => {
   const copyID = book.getAvailableCopyID();
   if (!copyID) return Promise.resolve(null);
 
-  return fetchFromAPI(`/copies/${copyID}/borrow`, 'POST').then(() => {
-    updateBookCopyUser(book, copyID, currentUser);
-  });
+  const response = await fetchFromAPI(`/copies/${copyID}/borrow`, 'POST');
+  updateBookCopyUser(book, copyID, currentUser);
+  return response;
 };
 
-export const returnBook = (book) => {
+export const returnBook = async (book) => {
   const copyID = book.getBorrowedCopyID();
   if (!copyID) return Promise.resolve(null);
 
-  return fetchFromAPI(`/copies/${copyID}/return`, 'POST').then(() => {
-    updateBookCopyUser(book, copyID, null);
-  });
+  const response = await fetchFromAPI(`/copies/${copyID}/return`, 'POST');
+  updateBookCopyUser(book, copyID, null);
+  return response;
 };
 
 export const joinWaitlist = async (library, book) => fetchFromAPI(`/libraries/${library}/books/${book.id}/waitlist/`, 'POST').then((data) => {

--- a/assets/src/services/BookService.js
+++ b/assets/src/services/BookService.js
@@ -52,7 +52,7 @@ export const returnBook = async (book) => {
   return response;
 };
 
-export const joinWaitlist = async (library, book) => fetchFromAPI(`/libraries/${library}/books/${book.id}/waitlist/`, 'POST').then((data) => {
+export const joinWaitlist = async (book, library) => fetchFromAPI(`/libraries/${library}/books/${book.id}/waitlist/`, 'POST').then((data) => {
   if ('waitlist_item' in data) return Promise.resolve(data.waitlist_item);
 
   return Promise.reject(new Error({ message: 'Request was successful, but no data was returned' }));

--- a/assets/src/services/BookService.test.js
+++ b/assets/src/services/BookService.test.js
@@ -159,7 +159,7 @@ describe('Book Service', () => {
 
       fetchFromAPI.mockResolvedValue({ waitlist_item: { book } });
 
-      await joinWaitlist('bh', book);
+      await joinWaitlist(book, 'bh');
       expect(fetchFromAPI).toHaveBeenCalledWith(`/libraries/bh/books/${book.id}/waitlist/`, 'POST');
     });
 
@@ -168,7 +168,7 @@ describe('Book Service', () => {
 
       fetchFromAPI.mockResolvedValue({ waitlist_item: 'mocked_waitlisted_item' });
 
-      const result = await joinWaitlist('bh', book);
+      const result = await joinWaitlist(book, 'bh');
       expect(result).toEqual('mocked_waitlisted_item');
     });
 
@@ -177,7 +177,7 @@ describe('Book Service', () => {
       fetchFromAPI.mockResolvedValue({});
 
       try {
-        await joinWaitlist('bh', book);
+        await joinWaitlist(book, 'bh');
       } catch (error) {
         expect(error).toEqual(new Error({ message: 'Request was successful, but no data was returned' }));
       }
@@ -188,7 +188,7 @@ describe('Book Service', () => {
       fetchFromAPI.mockRejectedValue({ status: 404 });
 
       try {
-        await joinWaitlist('bh', book);
+        await joinWaitlist(book, 'bh');
       } catch (error) {
         expect(error).toEqual({ status: 404 });
       }

--- a/assets/src/services/BookService.test.js
+++ b/assets/src/services/BookService.test.js
@@ -87,65 +87,69 @@ describe('Book Service', () => {
   });
 
   describe('Borrow book', () => {
-    it('should borrow a book that has an available copy and update the book copies with the user', () => {
+    it('should borrow a book that has an available copy and update the book copies with the user', async () => {
       const book = someBookWithAvailableCopies();
+      const expectedResponse = 'bla';
 
-      fetchFromAPI.mockResolvedValue({});
+      fetchFromAPI.mockResolvedValue(expectedResponse);
 
-      return borrowCopy(book).then(() => {
-        expect(book.copies[0].user).toEqual(currentUser);
-        expect(fetchFromAPI).toHaveBeenCalledWith(`/copies/${book.copies[0].id}/borrow`, 'POST');
-      });
+      const response = await borrowCopy(book);
+      expect(book.copies[0].user).toEqual(currentUser);
+      expect(fetchFromAPI).toHaveBeenCalledWith(`/copies/${book.copies[0].id}/borrow`, 'POST');
+      expect(response).toEqual(expectedResponse);
     });
 
-    it('shouldnt borrow a book when all copies are borrowed', () => {
+    it('shouldnt borrow a book when all copies are borrowed', async () => {
       const book = someBookWithNoAvailableCopies();
 
-      return borrowCopy(book).then(() => {
-        expect(book.copies[0].user).toEqual(someUser);
-        expect(fetchFromAPI).not.toHaveBeenCalled();
-      });
+      await borrowCopy(book);
+      expect(book.copies[0].user).toEqual(someUser);
+      expect(fetchFromAPI).not.toHaveBeenCalled();
     });
 
-    it('shouldnt mark the book as borrowed when the request fails', () => {
+    it('shouldnt mark the book as borrowed when the request fails', async () => {
       const book = someBookWithAvailableCopies();
 
       fetchFromAPI.mockRejectedValue(new Error('some error'));
 
-      return borrowCopy(book).catch(() => {
+      try {
+        await borrowCopy(book);
+      } catch (_) {
         expect(book.copies[0].user).toBeNull();
-      });
+      }
     });
   });
 
   describe('Return book', () => {
-    it('should return the book copy and remove the user from the copies', () => {
+    it('should return the book copy and remove the user from the copies', async () => {
       const book = someBookWithACopyFromMe();
+      const expectedResponse = 'bla';
 
-      fetchFromAPI.mockResolvedValue({});
+      fetchFromAPI.mockResolvedValue(expectedResponse);
 
-      return returnBook(book).then(() => {
-        expect(book.copies[0].user).toBeNull();
-        expect(fetchFromAPI).toHaveBeenCalledWith(`/copies/${book.copies[0].id}/return`, 'POST');
-      });
+      const response = await returnBook(book);
+      expect(book.copies[0].user).toBeNull();
+      expect(fetchFromAPI).toHaveBeenCalledWith(`/copies/${book.copies[0].id}/return`, 'POST');
+      expect(response).toEqual(expectedResponse);
     });
 
-    it('shouldnt return a book when doesnt belong to user', () => {
+    it('shouldnt return a book when doesnt belong to user', async () => {
       const book = someBookWithNoAvailableCopies();
 
-      return returnBook(book).then(() => {
-        expect(book.copies[0].user).toEqual(someUser);
-        expect(fetchFromAPI).not.toHaveBeenCalled();
-      });
+      await returnBook(book);
+      expect(book.copies[0].user).toEqual(someUser);
+      expect(fetchFromAPI).not.toHaveBeenCalled();
     });
 
-    it('shouldnt mark the book as returned when the request fails', () => {
+    it('shouldnt mark the book as returned when the request fails', async () => {
       const book = someBookWithACopyFromMe();
       fetchFromAPI.mockRejectedValue(new Error('some error'));
 
-      return returnBook(book).catch(() => {
+      try {
+        await returnBook(book);
+      } catch (_) {
         expect(book.copies[0].user).toEqual(currentUser);
-      });
+      }
     });
   });
 

--- a/assets/src/utils/constants.js
+++ b/assets/src/utils/constants.js
@@ -3,3 +3,6 @@ export const ADMIN_URL = '/admin';
 export const LIBRARY_URL_PREFIX = '/libraries';
 export const MY_BOOKS_URL = '/my-books';
 export const ADD_BOOK_URL = '/admin/books/book/isbn/';
+export const BORROW_BOOK_ACTION = 'BORROW';
+export const RETURN_BOOK_ACTION = 'RETURN';
+export const OIN_WAITLIST_BOOK_ACTION = 'JOIN_WAITLIST';

--- a/assets/src/utils/constants.js
+++ b/assets/src/utils/constants.js
@@ -5,4 +5,4 @@ export const MY_BOOKS_URL = '/my-books';
 export const ADD_BOOK_URL = '/admin/books/book/isbn/';
 export const BORROW_BOOK_ACTION = 'BORROW';
 export const RETURN_BOOK_ACTION = 'RETURN';
-export const OIN_WAITLIST_BOOK_ACTION = 'JOIN_WAITLIST';
+export const JOIN_WAITLIST_BOOK_ACTION = 'JOIN_WAITLIST';

--- a/assets/test/booksHelper.js
+++ b/assets/test/booksHelper.js
@@ -1,7 +1,12 @@
 import Book from '../src/models/Book';
 import { currentUser, someUser } from './userHelper';
+import { BORROW_BOOK_ACTION, RETURN_BOOK_ACTION, JOIN_WAITLIST_BOOK_ACTION } from '../src/utils/constants';
 
-export const someBook = (copies = [], waitlistUsers = []) => {
+export const borrowAction = { type: BORROW_BOOK_ACTION };
+export const returnAction = { type: RETURN_BOOK_ACTION };
+export const joinWaitlistAction = { type: JOIN_WAITLIST_BOOK_ACTION };
+
+export const someBook = (copies = [], waitlistUsers = [], action = borrowAction) => {
   const book = new Book();
 
   book.id = 1;
@@ -14,6 +19,7 @@ export const someBook = (copies = [], waitlistUsers = []) => {
   book.number_of_pages = 220;
   book.publication_date = '2003-05-17';
   book.publisher = 'Addison-Wesley Professional';
+  book.action = action;
 
   book.copies = copies;
   book.waitlist_users = waitlistUsers;
@@ -21,26 +27,38 @@ export const someBook = (copies = [], waitlistUsers = []) => {
   return book;
 };
 
-export const someBookWithNoAvailableCopies = () => someBook([
-  {
+export const someBookWithNoAvailableCopies = () => someBook(
+  [{
     id: 1,
     user: someUser,
     borrow_date: '2019-03-07',
-  },
-]);
+  }],
+  [],
+  joinWaitlistAction,
+);
 
-export const someBookWithAvailableCopies = () => someBook([
-  {
+export const someBookWithAvailableCopies = () => someBook(
+  [{
     id: 1,
     user: null,
-  },
-]);
+  }],
+);
 
-export const someBookWithACopyFromMe = () => someBook([
-  {
+export const someBookWithACopyFromMe = () => someBook(
+  [{
     id: 1,
     user: currentUser,
-  },
-]);
+  }],
+  [],
+  returnAction,
+);
 
-export const someBookThatCanBeAddedToWaitlist = () => someBookWithNoAvailableCopies();
+export const someBookThatCanBeAddedToWaitlist = () => someBook(
+  [{
+    id: 1,
+    user: someUser,
+    borrow_date: '2019-03-07',
+  }],
+  [],
+  joinWaitlistAction,
+);

--- a/books/models.py
+++ b/books/models.py
@@ -16,6 +16,9 @@ class Book(models.Model):
     def __str__(self):
         return "%s (%s)" % (self.title, self.author)
 
+    def is_available(self, library):
+        return self.bookcopy_set.filter(library=library, user=None).exists()
+
 
 class Library(models.Model):
     name = models.CharField(max_length=255)

--- a/books/models.py
+++ b/books/models.py
@@ -5,8 +5,9 @@ BOOK_RETURN_ACTION = 'RETURN'
 BOOK_BORROW_ACTION = 'BORROW'
 BOOK_JOIN_WAITLIST_ACTION = 'JOIN_WAITLIST'
 
+
 def create_book_action(type):
-    return { 'type': type }
+    return {'type': type}
 
 class Book(models.Model):
     author = models.CharField(max_length=255)

--- a/books/models.py
+++ b/books/models.py
@@ -1,6 +1,12 @@
 from django.conf import settings
 from django.db import models
 
+BOOK_RETURN_ACTION = 'RETURN'
+BOOK_BORROW_ACTION = 'BORROW'
+BOOK_JOIN_WAITLIST_ACTION = 'JOIN_WAITLIST'
+
+def create_book_action(type):
+    return { 'type': type }
 
 class Book(models.Model):
     author = models.CharField(max_length=255)
@@ -30,11 +36,11 @@ class Book(models.Model):
 
     def available_action(self, user, library=None):
         if self.is_borrowed_by_user(user, library):
-            return 'Return'
+            return create_book_action(BOOK_RETURN_ACTION)
         if self.is_available(library):
-            return 'Borrow'
+            return create_book_action(BOOK_BORROW_ACTION)
         if not self.is_on_users_waitlist(user, library):
-            return 'Join the Waitlist'
+            return create_book_action(BOOK_JOIN_WAITLIST_ACTION)
         return None
 
 

--- a/books/models.py
+++ b/books/models.py
@@ -22,6 +22,18 @@ class Book(models.Model):
     def is_borrowed_by_user(self, library, user):
         return self.bookcopy_set.filter(library=library, user=user).exists()
 
+    def is_on_users_waitlist(self, library, user):
+        return self.waitlistitem_set.filter(library=library, user=user).exists()
+
+    def available_action(self, library, user):
+        if self.is_borrowed_by_user(library, user):
+            return 'Return'
+        if self.is_available(library):
+            return 'Borrow'
+        if not self.is_on_users_waitlist(library, user):
+            return 'Join the Waitlist'
+        return None
+
 
 class Library(models.Model):
     name = models.CharField(max_length=255)

--- a/books/models.py
+++ b/books/models.py
@@ -19,6 +19,9 @@ class Book(models.Model):
     def is_available(self, library):
         return self.bookcopy_set.filter(library=library, user=None).exists()
 
+    def is_borrowed_by_user(self, library, user):
+        return self.bookcopy_set.filter(library=library, user=user).exists()
+
 
 class Library(models.Model):
     name = models.CharField(max_length=255)

--- a/books/models.py
+++ b/books/models.py
@@ -19,18 +19,21 @@ class Book(models.Model):
     def is_available(self, library):
         return self.bookcopy_set.filter(library=library, user=None).exists()
 
-    def is_borrowed_by_user(self, library, user):
-        return self.bookcopy_set.filter(library=library, user=user).exists()
+    def is_borrowed_by_user(self, user, library=None):
+        user_copies = self.bookcopy_set.filter(user=user)
+        if library is not None:
+            user_copies = user_copies.filter(library=library)
+        return user_copies.exists()
 
-    def is_on_users_waitlist(self, library, user):
-        return self.waitlistitem_set.filter(library=library, user=user).exists()
+    def is_on_users_waitlist(self, user, library):
+        return self.waitlistitem_set.filter(user=user, library=library).exists()
 
-    def available_action(self, library, user):
-        if self.is_borrowed_by_user(library, user):
+    def available_action(self, user, library=None):
+        if self.is_borrowed_by_user(user, library):
             return 'Return'
         if self.is_available(library):
             return 'Borrow'
-        if not self.is_on_users_waitlist(library, user):
+        if not self.is_on_users_waitlist(user, library):
             return 'Join the Waitlist'
         return None
 

--- a/books/serializers.py
+++ b/books/serializers.py
@@ -40,6 +40,7 @@ class BookSerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField()
     copies = serializers.SerializerMethodField()
     waitlist_users = serializers.SerializerMethodField()
+    action = serializers.SerializerMethodField()
 
     class Meta:
         model = Book
@@ -60,6 +61,12 @@ class BookSerializer(serializers.ModelSerializer):
             waitlist_items = obj.waitlistitem_set.all()
         serializer = UserSerializer(list(map(lambda item: item.user, waitlist_items)), many=True)
         return serializer.data
+
+    def get_action(self, obj):
+        return obj.available_action(
+            library=self.context.get('library'),
+            user=self.context.get('user'),
+        )
 
 
 class BookCompactSerializer(serializers.ModelSerializer):

--- a/books/test/test_models.py
+++ b/books/test/test_models.py
@@ -6,14 +6,36 @@ from django.db.utils import IntegrityError
 from books.models import Book, BookCopy, Library
 
 
-# MODELS
 class BookTestCase(TestCase):
-    def test_can_create_book(self):
+    def setUp(self):
         self.book = Book.objects.create(author="Author", title="the title", subtitle="The subtitle",
                                         publication_date=timezone.now())
+        self.library = Library.objects.create(name="Santiago", slug="slug")
+        self.library2 = Library.objects.create(name="Santiago", slug="slug")
+        self.user = User.objects.create(username="claudia", email="claudia@gmail.com")
+
+    def test_can_create_book(self):
         self.assertEqual(self.book.author, "Author")
         self.assertEqual(self.book.title, "the title")
         self.assertEqual(self.book.subtitle, "The subtitle")
+
+    def test_is_available_if_has_a_copy_with_no_user_on_library(self):
+        self.book.bookcopy_set.create(library=self.library, user=None)
+        self.book.bookcopy_set.create(library=self.library2, user=self.user)
+        self.assertTrue(self.book.is_available(self.library))
+
+    def test_is_available_if_has_at_least_one_copy_with_no_user_on_library(self):
+        self.book.bookcopy_set.create(library=self.library, user=self.user)
+        self.book.bookcopy_set.create(library=self.library, user=None)
+        self.assertTrue(self.book.is_available(self.library))
+
+    def test_is_not_available_if_book_has_no_copies_on_library(self):
+        self.book.bookcopy_set.create(library=self.library2, user=None)
+        self.assertFalse(self.book.is_available(self.library))
+
+    def test_is_not_available_if_all_copies_on_library_have_a_user(self):
+        self.book.bookcopy_set.create(library=self.library, user=self.user)
+        self.assertFalse(self.book.is_available(self.library))
 
 
 class LibraryTestCase(TestCase):

--- a/books/test/test_models.py
+++ b/books/test/test_models.py
@@ -56,24 +56,32 @@ class BookTestCase(TestCase):
 
     def test_has_borrow_action_when_user_has_not_borrowed_and_there_is_a_copy_available(self):
         self.book.bookcopy_set.create(library=self.library, user=None)
-        self.assertEqual('Borrow', self.book.available_action(library=self.library, user=self.user))
+        action = self.book.available_action(library=self.library, user=self.user)
+        self.assertBookAction('BORROW', action)
 
     def test_has_return_action_when_user_has_borrowed_a_copy(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user)
-        self.assertEqual('Return', self.book.available_action(library=self.library, user=self.user))
+        action = self.book.available_action(library=self.library, user=self.user)
+        self.assertBookAction('RETURN', action)
 
     def test_has_return_action_when_library_unspecified_and_user_has_borrowed_a_copy(self):
         self.book.bookcopy_set.create(library=self.library2, user=self.user)
-        self.assertEqual('Return', self.book.available_action(user=self.user))
+        action = self.book.available_action(user=self.user)
+        self.assertBookAction('RETURN', action)
 
     def test_has_join_waitlist_action_when_user_has_not_borrowed_and_no_copies_are_available(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user2)
-        self.assertEqual('Join the Waitlist', self.book.available_action(library=self.library, user=self.user))
+        action = self.book.available_action(library=self.library, user=self.user)
+        self.assertBookAction('JOIN_WAITLIST', action)
 
     def test_does_not_have_action_when_user_is_already_on_waitlist(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user2)
         self.book.waitlistitem_set.create(library=self.library, user=self.user, added_date=timezone.now())
-        self.assertIsNone(self.book.available_action(library=self.library, user=self.user))
+        action = self.book.available_action(library=self.library, user=self.user)
+        self.assertIsNone(action)
+
+    def assertBookAction(self, type, actual):
+        self.assertEqual(type, actual['type'])
 
 
 class LibraryTestCase(TestCase):

--- a/books/test/test_models.py
+++ b/books/test/test_models.py
@@ -37,6 +37,18 @@ class BookTestCase(TestCase):
         self.book.bookcopy_set.create(library=self.library, user=self.user)
         self.assertFalse(self.book.is_available(self.library))
 
+    def test_is_borrowed_if_user_has_a_copy_on_library(self):
+        self.book.bookcopy_set.create(library=self.library, user=self.user)
+        self.assertTrue(self.book.is_borrowed_by_user(self.library, self.user))
+
+    def test_is_not_borrowed_if_user_does_not_have_a_copy_on_library(self):
+        self.book.bookcopy_set.create(library=self.library, user=None)
+        self.assertFalse(self.book.is_borrowed_by_user(self.library, self.user))
+
+    def test_is_not_borrowed_if_user_has_a_copy_on_other_library(self):
+        self.book.bookcopy_set.create(library=self.library2, user=self.user)
+        self.assertFalse(self.book.is_borrowed_by_user(self.library, self.user))
+
 
 class LibraryTestCase(TestCase):
     def test_can_create_library(self):

--- a/books/test/test_models.py
+++ b/books/test/test_models.py
@@ -40,32 +40,40 @@ class BookTestCase(TestCase):
 
     def test_is_borrowed_if_user_has_a_copy_on_library(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user)
-        self.assertTrue(self.book.is_borrowed_by_user(self.library, self.user))
+        self.assertTrue(self.book.is_borrowed_by_user(library=self.library, user=self.user))
 
     def test_is_not_borrowed_if_user_does_not_have_a_copy_on_library(self):
         self.book.bookcopy_set.create(library=self.library, user=None)
-        self.assertFalse(self.book.is_borrowed_by_user(self.library, self.user))
+        self.assertFalse(self.book.is_borrowed_by_user(library=self.library, user=self.user))
 
     def test_is_not_borrowed_if_user_has_a_copy_on_other_library(self):
         self.book.bookcopy_set.create(library=self.library2, user=self.user)
-        self.assertFalse(self.book.is_borrowed_by_user(self.library, self.user))
+        self.assertFalse(self.book.is_borrowed_by_user(library=self.library, user=self.user))
+
+    def test_is_borrowed_if_library_not_specified_and_user_has_a_copy(self):
+        self.book.bookcopy_set.create(library=self.library, user=self.user)
+        self.assertTrue(self.book.is_borrowed_by_user(user=self.user))
 
     def test_has_borrow_action_when_user_has_not_borrowed_and_there_is_a_copy_available(self):
         self.book.bookcopy_set.create(library=self.library, user=None)
-        self.assertEqual('Borrow', self.book.available_action(self.library, self.user))
+        self.assertEqual('Borrow', self.book.available_action(library=self.library, user=self.user))
 
     def test_has_return_action_when_user_has_borrowed_a_copy(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user)
-        self.assertEqual('Return', self.book.available_action(self.library, self.user))
+        self.assertEqual('Return', self.book.available_action(library=self.library, user=self.user))
+
+    def test_has_return_action_when_library_unspecified_and_user_has_borrowed_a_copy(self):
+        self.book.bookcopy_set.create(library=self.library2, user=self.user)
+        self.assertEqual('Return', self.book.available_action(user=self.user))
 
     def test_has_join_waitlist_action_when_user_has_not_borrowed_and_no_copies_are_available(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user2)
-        self.assertEqual('Join the Waitlist', self.book.available_action(self.library, self.user))
+        self.assertEqual('Join the Waitlist', self.book.available_action(library=self.library, user=self.user))
 
     def test_does_not_have_action_when_user_is_already_on_waitlist(self):
         self.book.bookcopy_set.create(library=self.library, user=self.user2)
         self.book.waitlistitem_set.create(library=self.library, user=self.user, added_date=timezone.now())
-        self.assertIsNone(self.book.available_action(self.library, self.user))
+        self.assertIsNone(self.book.available_action(library=self.library, user=self.user))
 
 
 class LibraryTestCase(TestCase):

--- a/books/test/test_views.py
+++ b/books/test/test_views.py
@@ -123,8 +123,8 @@ class LibraryViewSet(TestCase):
         response = json.loads(json.dumps(response.data))
         books = response['results']
 
-        self.assertEqual(books[0]['action'], 'Borrow')
-        self.assertEqual(books[1]['action'], 'Return')
+        self.assertEqual(books[0]['action']['type'], 'BORROW')
+        self.assertEqual(books[1]['action']['type'], 'RETURN')
 
 
 class LibraryViewSetQueryParameters(TestCase):
@@ -266,7 +266,7 @@ class UserBooksViewTest(TestCase):
     def test_has_return_action_for_each_book(self):
         response = self.client.get("/api/profile/books")
 
-        self.assertEqual(response.data['results'][0]['action'], 'Return')
+        self.assertEqual(response.data['results'][0]['action']['type'], 'RETURN')
 
 
 class IsbnViewTest(TestCase):

--- a/books/test/test_views.py
+++ b/books/test/test_views.py
@@ -76,50 +76,55 @@ class LibraryViewSet(TestCase):
         self.user.save()
         self.client.force_login(user=self.user)
 
-        self.book = Book.objects.create(author="Author", title="the title", subtitle="The subtitle",
-                                        publication_date=timezone.now())
         self.library = Library.objects.create(name="Santiago", slug="slug")
-        self.bookCopy = BookCopy.objects.create(book=self.book, library=self.library)
+        self.book = Book.objects.create(author="Author", title="Book A", subtitle="The subtitle",
+                                        publication_date=timezone.now())
+        self.book.bookcopy_set.create(library=self.library)
 
-    def test_user_can_retrieve_library_information_with_existing_slug(self):
+    def test_can_retrieve_library_information_with_existing_slug(self):
         """tests the following url: /api/libraries/(?P<library_slug>)/books/"""
 
-        self.request = self.client.get("/api/libraries/" + self.library.slug + "/")
+        response = self.client.get("/api/libraries/" + self.library.slug + "/")
 
-        self.assertEqual(self.request.status_code, 200)
-
-        library_json = json.loads(json.dumps(self.request.data))
-
-        self.assertEqual(self.library.name, library_json['name'])
-        self.assertEqual(self.library.slug, library_json['slug'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.library.name, response.data['name'])
+        self.assertEqual(self.library.slug, response.data['slug'])
 
         # Get the books
-        self.request = self.client.get(library_json['books'])
+        response = self.client.get(response.data['books'])
 
-        self.assertEqual(self.request.status_code, 200)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(1, response.data['count'])
+        self.assertEqual(1, len(response.data['results'][0]['copies']))
 
-        library_json = json.loads(json.dumps(self.request.data))
+    def test_can_retrieve_books_from_library(self):
+        response = self.client.get("/api/libraries/" + self.library.slug + "/books/")
 
-        self.assertEqual(1, library_json['count'])
-        self.assertEqual(1, len(library_json['results'][0]['copies']))
+        self.assertEqual(response.status_code, 200)
 
-    def test_user_can_retrieve_books_from_library(self):
-        self.request = self.client.get("/api/libraries/" + self.library.slug + "/books/")
+        response = json.loads(json.dumps(response.data))
 
-        self.assertEqual(self.request.status_code, 200)
+        self.assertEqual(response['count'], 1)
+        self.assertIsNone(response['next'])
+        self.assertIsNone(response['previous'])
+        self.assertEqual(len(response['results']), 1)
 
-        request_data = json.loads(json.dumps(self.request.data))
-
-        self.assertEqual(request_data['count'], 1)
-        self.assertIsNone(request_data['next'])
-        self.assertIsNone(request_data['previous'])
-        self.assertEqual(len(request_data['results']), 1)
-
-        book = request_data['results'][0]
-
+        book = response['results'][0]
         self.assertEqual(book['title'], self.book.title)
         self.assertEqual(book['author'], self.book.author)
         self.assertEqual(book['subtitle'], self.book.subtitle)
+
+    def test_has_action_for_each_book(self):
+        book2 = Book.objects.create(author="Author", title="Book B")
+        book2.bookcopy_set.create(library=self.library, user=self.user)
+
+        response = self.client.get("/api/libraries/" + self.library.slug + "/books/")
+
+        response = json.loads(json.dumps(response.data))
+        books = response['results']
+
+        self.assertEqual(books[0]['action'], 'Borrow')
+        self.assertEqual(books[1]['action'], 'Return')
 
 
 class LibraryViewSetQueryParameters(TestCase):
@@ -159,7 +164,6 @@ class LibraryViewSetQueryParameters(TestCase):
         self.assertEqual(len(books), 4)
 
     def test_search_for_books_title(self):
-
         books = self.get_request_result_as_json(self.base_url + "book_title=invalid")
         self.assertEqual(len(books), 0)
 
@@ -182,7 +186,6 @@ class LibraryViewSetQueryParameters(TestCase):
         self.assertEqual(len(books), 1)
 
     def test_search_for_books_author(self):
-
         books = self.get_request_result_as_json(self.base_url + "book_author=invalid")
         self.assertEqual(len(books), 0)
 
@@ -246,18 +249,24 @@ class UserBooksViewTest(TestCase):
         self.user.save()
         self.client.force_login(user=self.user)
 
+        self.library = Library.objects.create(name="Santiago", slug="slug")
+        self.book = Book.objects.create(author="Author", title="The title")
+        self.book.bookcopy_set.create(library=self.library, user=self.user)
+
     def test_user_should_get_their_borrowed_books(self):
-        library = Library.objects.create(name="Santiago", slug="slug")
-        book = Book.objects.create(author="Author", title="the title", subtitle="The subtitle")
-        BookCopy.objects.create(book=book, library=library, user=self.user)
-        availableBook = Book.objects.create(author="Author", title="the title", subtitle="The subtitle")
-        BookCopy.objects.create(book=availableBook, library=library)
+        availableBook = Book.objects.create(author="Author", title="Another title")
+        availableBook.bookcopy_set.create(library=self.library)
 
         response = self.client.get("/api/profile/books")
 
         self.assertEqual(200, response.status_code)
         self.assertEqual(len(response.data['results']), 1)
-        self.assertEqual(BookSerializer(book).data, response.data['results'][0])
+        self.assertEqual(response.data['results'][0]['title'], self.book.title)
+
+    def test_has_return_action_for_each_book(self):
+        response = self.client.get("/api/profile/books")
+
+        self.assertEqual(response.data['results'][0]['action'], 'Return')
 
 
 class IsbnViewTest(TestCase):

--- a/books/views.py
+++ b/books/views.py
@@ -140,7 +140,13 @@ class BookCopyBorrowView(APIView):
             book_copy.save()
         except BookCopy.DoesNotExist:
             raise Http404("Book Copy not found")
-        return Response({'status': 'Book borrowed'})
+        return Response({
+            'status': 'Book borrowed',
+            'action': book_copy.book.available_action(
+                library=book_copy.library,
+                user=request.user,
+            )
+        })
 
 
 class BookCopyReturnView(APIView):
@@ -152,7 +158,13 @@ class BookCopyReturnView(APIView):
             book_copy.save()
         except:
             raise Http404("Book Copy not found")
-        return Response({'status': 'Book returned'})
+        return Response({
+            'status': 'Book returned',
+            'action': book_copy.book.available_action(
+                library=book_copy.library,
+                user=request.user,
+            )
+        })
 
 
 class UserView(APIView):

--- a/books/views.py
+++ b/books/views.py
@@ -45,7 +45,7 @@ class IsbnFormView(View):
             isbn = form.cleaned_data["isbn"]
             book_from_db = BookModel.objects.filter(isbn=isbn).distinct()
             book = BookFinder.fetch(isbn)
-            
+
             if book_from_db:
                  messages.warning(request, 'The requested book is on the table.')
                  return self.get(request)
@@ -117,7 +117,11 @@ class BookViewSet(FiltersMixin, viewsets.ModelViewSet):
 
         page = self.paginate_queryset(books)
 
-        serializer = BookSerializer(page, many=True, context={'request': request, 'library': library})
+        serializer = BookSerializer(page, many=True, context={
+            'request': request,
+            'library': library,
+            'user': request.user,
+        })
 
         return self.get_paginated_response(serializer.data)
 
@@ -161,5 +165,5 @@ class UserBooksView(APIView):
     def get(self, request, format=None):
         books = Book.objects.filter(bookcopy__user=request.user)
         return Response({
-            'results': BookSerializer(books, many=True).data
+            'results': BookSerializer(books, many=True, context={'user': request.user}).data
         })

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 100


### PR DESCRIPTION
- [x] Return book borrow/return action according to current user
- [x] Return 'Add to waitlist' action when all copies are borrowed
- [x] Return an object of an action instead of string so that it can be extensible (for example, to receive action endpoint)
- [x] Change frontend to determine action from the API

Closes #98

A future PR will add borrow/return endpoints directly on book, without depending on book copy (to fix #99). It will complement this PR as it will reduce business logic even further from the frontend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/101)
<!-- Reviewable:end -->
