### PR TITLE
Fixes backend's test coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = .
+omit = venv/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
This changes:
- backend test coverage now omits `venv` folder (external dependencies)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/103)
<!-- Reviewable:end -->
