### PR TITLE
Allow searching a library's books by ISBN

### DIFF
--- a/books/test/test_views.py
+++ b/books/test/test_views.py
@@ -88,13 +88,13 @@ class LibraryViewSetQueryParameters(TestCase):
 
         self.base_url = "/api/libraries/" + self.library.slug + "/books/?"
 
-        books_info = [("author a", "book a"), ("author b", "book b"),
-                      ("author not", "book not"), ("author amazing", "book amazing")]
+        books_info = [("author a", "book a", "1001"), ("author b", "book b", "1002"),
+                      ("author not", "book not", "2003"), ("author amazing", "book amazing", "2004")]
 
         books_dict = []
 
         for book_info in books_info:
-            books_dict.append({"author": book_info[0], "title": book_info[1]})
+            books_dict.append({"author": book_info[0], "title": book_info[1], "isbn": book_info[2]})
 
         for book_dict in books_dict:
             book = Book.objects.create(**book_dict)
@@ -166,6 +166,11 @@ class LibraryViewSetQueryParameters(TestCase):
 
         books = self.get_request_result_as_json(self.base_url + "book_author=author amazing&book_title=book amazing")
         self.assertEqual(len(books), 1)
+
+    def test_search_for_books_isbn_returns_exact_match(self):
+        books = self.get_request_result_as_json(self.base_url + "book_isbn=1001")
+        self.assertEqual(len(books), 1)
+        self.assertEqual(books[0]['title'], 'book a')
 
 
 class BookViewSetTest(TestCase):

--- a/books/test/test_views.py
+++ b/books/test/test_views.py
@@ -88,13 +88,12 @@ class LibraryViewSetQueryParameters(TestCase):
 
         self.base_url = "/api/libraries/" + self.library.slug + "/books/?"
 
-        books_info = [("author a", "book a", "1001"), ("author b", "book b", "1002"),
-                      ("author not", "book not", "2003"), ("author amazing", "book amazing", "2004")]
-
-        books_dict = []
-
-        for book_info in books_info:
-            books_dict.append({"author": book_info[0], "title": book_info[1], "isbn": book_info[2]})
+        books_dict = [
+            {'author': 'author a', 'title': 'book a', 'isbn': '1001'},
+            {'author': 'author b', 'title': 'book b', 'isbn': '1002'},
+            {'author': 'author not', 'title': 'book not', 'isbn': '2003'},
+            {'author': 'author amazing', 'title': 'book amazing', 'isbn': '2004'},
+        ]
 
         for book_dict in books_dict:
             book = Book.objects.create(**book_dict)

--- a/books/views.py
+++ b/books/views.py
@@ -110,7 +110,7 @@ class BookViewSet(FiltersMixin, viewsets.ModelViewSet):
 
         library = Library.objects.get(slug=library_slug)
 
-        book_filters = get_book_filters_from_request(request, ('book_title', 'book_author'))
+        book_filters = get_book_filters_from_request(request, ('book_title', 'book_author', 'book_isbn'))
         book_filters.add(Q(bookcopy__library__slug__exact=library_slug), Q.AND)
 
         books = self.queryset.filter(book_filters).order_by('title')


### PR DESCRIPTION
This implements #110 only **partially**.

By providing a query parameter `book_isbn` the user is able to search the library's book by ISBN.

This does not implement "fuzzy" search - i.e. when there is a search by ISBN but we cannot find matches, in which case we should search by the book details (author, title, etc.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/112)
<!-- Reviewable:end -->
