### PR TITLE
Return list of libraries on the API in alphabetical order

### DIFF
--- a/books/test/test_views.py
+++ b/books/test/test_views.py
@@ -19,14 +19,25 @@ class LibraryViewSet(TestCase):
         self.user.save()
         self.client.force_login(user=self.user)
 
-        self.library = Library.objects.create(name="Santiago", slug="slug")
+        self.library = Library.objects.create(name="Santiago", slug="scl")
+        self.library2 = Library.objects.create(name="Belo Horizonte", slug="bh")
         self.book = Book.objects.create(author="Author", title="Book A", subtitle="The subtitle",
                                         publication_date=timezone.now())
         self.book.bookcopy_set.create(library=self.library)
 
-    def test_can_retrieve_library_information_with_existing_slug(self):
-        """tests the following url: /api/libraries/(?P<library_slug>)/books/"""
+    def test_returns_the_list_of_libraries_ordered_alphabetically(self):
+        response = self.client.get("/api/libraries/")
 
+        self.assertEqual(response.status_code, 200)
+
+        libraries = response.data['results']
+        self.assertEqual(2, response.data['count'])
+        self.assertEqual(self.library2.name, libraries[0]['name'])
+        self.assertEqual(self.library2.slug, libraries[0]['slug'])
+        self.assertEqual(self.library.name, libraries[1]['name'])
+        self.assertEqual(self.library.slug, libraries[1]['slug'])
+
+    def test_can_retrieve_library_information_with_existing_slug(self):
         response = self.client.get("/api/libraries/" + self.library.slug + "/")
 
         self.assertEqual(response.status_code, 200)

--- a/books/views.py
+++ b/books/views.py
@@ -88,7 +88,7 @@ class LibraryViewSet(FiltersMixin, viewsets.ModelViewSet):
     lookup_field = 'slug'
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = ('id', 'name')
-    ordering = ('id',)  # default ordering
+    ordering = ('name')
 
     # add a mapping of query_params to db_columns(queries)
     filter_mappings = {


### PR DESCRIPTION
Changing the default order of the libraries API to use the library's name and adding a test for this behavior.

Closes #105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/113)
<!-- Reviewable:end -->
