### PR TITLE
Keep the old query params when querying for book

### DIFF
--- a/assets/src/components/libraries/Library.jsx
+++ b/assets/src/components/libraries/Library.jsx
@@ -54,16 +54,26 @@ class Library extends Component {
         hasNextPage: !!booksResponse.next,
         isLoading: false,
       }));
-
-      this.props.history.replace({
-        search: searchTerm ? new URLSearchParams({ q: searchTerm }).toString() : null,
-      });
     } catch (e) {
       this.setState({
         hasError: true,
         isLoading: false,
       });
     }
+  }
+
+  updateQueryString() {
+    const { searchTerm } = this.state;
+    const queryString = new URLSearchParams(this.props.history.location.search);
+    if (searchTerm) {
+      queryString.set('q', searchTerm);
+    } else {
+      queryString.delete('q');
+    }
+
+    this.props.history.replace({
+      search: queryString.toString(),
+    });
   }
 
   searchTermChanged(searchTerm) {
@@ -74,6 +84,7 @@ class Library extends Component {
       hasNextPage: false,
     }, () => {
       this.loadBooks();
+      this.updateQueryString();
     });
   }
 

--- a/assets/src/components/libraries/Library.test.jsx
+++ b/assets/src/components/libraries/Library.test.jsx
@@ -12,7 +12,7 @@ import ErrorMessage from '../error/ErrorMessage';
 jest.mock('../../services/BookService');
 jest.mock('../../services/ProfileService');
 
-const history = { replace: jest.fn(), location: { search: null } };
+const history = { replace: jest.fn(), location: { search: '' } };
 const createComponent = (props) => shallow(<Library slug="bh" history={history} {...props} />);
 
 describe('Library', () => {
@@ -132,6 +132,19 @@ describe('Library', () => {
     expect(history.replace).toHaveBeenCalledWith({ search: 'q=test+search' });
   });
 
+  it('keeps the previous query params in the url even when search is updated', async () => {
+    history.location.search = '?toggle=active';
+    getBooksByPage.mockReturnValue(mockGetBooksByPageEmptyResponse);
+    const searchBar = library.find(SearchBar);
+    const infiniteScroll = library.find(InfiniteScroll);
+
+    searchBar.props().onChange('test search');
+    await infiniteScroll.props().loadMore();
+
+    expect(history.replace).toHaveBeenCalledWith({ search: 'toggle=active&q=test+search' });
+    history.location.search = '';
+  });
+
   it('removes the search query from the url when search field is empty', async () => {
     getBooksByPage.mockReturnValue(mockGetBooksByPageEmptyResponse);
     const searchBar = library.find(SearchBar);
@@ -140,7 +153,7 @@ describe('Library', () => {
     searchBar.props().onChange('');
     await infiniteScroll.props().loadMore();
 
-    expect(history.replace).toHaveBeenCalledWith({ search: null });
+    expect(history.replace).toHaveBeenCalledWith({ search: '' });
   });
 
   it('clears the previous books when searching', () => {


### PR DESCRIPTION
This was preventing us to use query toggles (e.g waitlist) in library view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/116)
<!-- Reviewable:end -->
