### PR TITLE
Change condition to check for user and not borrow_date

### DIFF
--- a/waitlist/models.py
+++ b/waitlist/models.py
@@ -16,7 +16,7 @@ class WaitlistItem(models.Model):
             book=book, library=library,
         )
         if copies.count():
-            available_copies = copies.filter(borrow_date=None)
+            available_copies = copies.filter(user=None)
             if available_copies.count() is 0:
                 return WaitlistItem.objects.create(
                     book=book,

--- a/waitlist/test/test_models.py
+++ b/waitlist/test/test_models.py
@@ -79,7 +79,7 @@ class CreateItemTest(TestCase):
                                         publication_date=timezone.now())
         self.library = Library.objects.create(name="Santiago", slug="slug")
         self.user = User.objects.create(username="claudia", email="claudia@gmail.com")
-        self.copy = BookCopy.objects.create(book=self.book, library=self.library, borrow_date=timezone.now())
+        self.copy = BookCopy.objects.create(book=self.book, library=self.library, user=self.user)
 
     def test_should_create_waitlist_item_and_return_its_value(self):
         initialCount = WaitlistItem.objects.all().count()
@@ -103,7 +103,7 @@ class CreateItemTest(TestCase):
         self.assertIsInstance(item, WaitlistItem)
 
     def test_should_not_create_waitlist_item_and_raise_exception_if_there_are_available_copies(self):
-        self.copy.borrow_date = None
+        self.copy.user = None
         self.copy.save()
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
For books that were borrowed a long time ago, the database might not have the borrow_date data. That's why we're changing the condition to check for user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/120)
<!-- Reviewable:end -->
