### PR TITLE
Persist toggle state to local storage

### DIFF
--- a/assets/src/components/books/Book.test.jsx
+++ b/assets/src/components/books/Book.test.jsx
@@ -11,8 +11,10 @@ import {
   someBookThatCanBeAddedToWaitlist,
 } from '../../../test/booksHelper';
 import { borrowBook, returnBook, joinWaitlist } from '../../services/BookService';
+import { isWaitlistFeatureActive } from '../../utils/toggles';
 
 jest.mock('../../services/BookService');
+jest.mock('../../utils/toggles');
 
 expect.extend({
   toHaveBorrowButton(received) {
@@ -125,8 +127,8 @@ describe('Book', () => {
   });
 
   describe('if waitlist feature is enabled', () => {
-    beforeAll(() => {
-      window.history.pushState({}, 'Testing with Waitlist Enabled', '/?waitlist=active');
+    beforeEach(() => {
+      isWaitlistFeatureActive.mockReturnValue(true);
     });
 
     it('shows the join waitlist button when book can be added to waitlist', async () => {
@@ -149,8 +151,8 @@ describe('Book', () => {
   });
 
   describe('if waitlist feature is disabled', () => {
-    beforeAll(() => {
-      window.history.pushState({}, 'Testing with Waitlist Disabled', '/');
+    beforeEach(() => {
+      isWaitlistFeatureActive.mockReturnValue(false);
     });
 
     it('does not show the join waitlist button when book can be added to waitlist', async () => {

--- a/assets/src/services/UserPreferences.test.js
+++ b/assets/src/services/UserPreferences.test.js
@@ -2,8 +2,6 @@ import {
   getRegion, setRegion, clearRegion, getDefaultTheme, setDefaultTheme,
 } from './UserPreferences';
 
-jest.mock('./helpers');
-
 const region = 'quito';
 
 describe('UserPreferences', () => {

--- a/assets/src/utils/toggles.js
+++ b/assets/src/utils/toggles.js
@@ -1,10 +1,18 @@
 import parse from 'url-parse';
 
-export const isWaitlistFeatureActive = () => {
+export const isToggleOn = (toggle) => {
+  const isActive = (value) => value === 'on';
+  const toggleKey = `toggle-${toggle}`;
   const { query } = parse(window.location.href, true);
-  return 'waitlist' in query && query.waitlist === 'active';
+  if (toggle in query) {
+    localStorage.setItem(toggleKey, query[toggle]);
+  }
+  return isActive(localStorage.getItem(toggleKey));
 };
 
+export const isWaitlistFeatureActive = () => isToggleOn('waitlist');
+
 export default {
+  isToggleOn,
   isWaitlistFeatureActive,
 };

--- a/assets/src/utils/toggles.test.js
+++ b/assets/src/utils/toggles.test.js
@@ -1,0 +1,42 @@
+import { isToggleOn } from './toggles';
+
+const toggle = 'test';
+const toggleKey = 'toggle-test';
+
+describe('Toggles helper', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should return false when toggle is not stored neither overriden', () => {
+    expect(isToggleOn(toggle)).toBeFalsy();
+  });
+
+  it('should return true when toggle is stored as ON and it is not overriden', () => {
+    localStorage.setItem(toggleKey, 'on');
+    expect(isToggleOn(toggle)).toBeTruthy();
+  });
+
+  it('should return false when toggle is stored as OFF and it is not overriden', () => {
+    localStorage.setItem(toggleKey, 'off');
+    expect(isToggleOn(toggle)).toBeFalsy();
+  });
+
+  it('should return true when toggle is stored as OFF but it is overriden as ON', () => {
+    window.history.pushState({}, 'Testing with toggle on', '/?test=on');
+    localStorage.setItem(toggleKey, 'off');
+    expect(isToggleOn(toggle)).toBeTruthy();
+  });
+
+  it('should return false when toggle is stored as ON but it is overriden as OFF', () => {
+    window.history.pushState({}, 'Testing with toggle off', '/?test=off');
+    localStorage.setItem(toggleKey, 'on');
+    expect(isToggleOn(toggle)).toBeFalsy();
+  });
+
+  it('should persist the state in local storage when it is overriden', () => {
+    window.history.pushState({}, 'Testing with toggle off', '/?test=bla');
+    expect(isToggleOn(toggle)).toBeFalsy();
+    expect(localStorage.getItem(toggleKey)).toEqual('bla');
+  });
+});


### PR DESCRIPTION
This improves the toggle logic for the waitlist feature, allowing the user to provide it only once and have it persisted during the navigation. It also allows this logic to be used for next features.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/140)
<!-- Reviewable:end -->
