### PR TITLE
Removes Sentry reporting for development environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ DATABASE_URL="" # This variable should be automatically configured by the postgr
 ALLOWED_HOSTS="kamu.example.com" # At this moment, only one domain is supported
 OKTA_METADATA_URL="SECRET-OKTA-STUFF" # On the case of Okta Authentication support
 ANALYTICS_ACCOUNT_ID="UA-123456789-1" # Only if you want to enable Google Analytics, otherwise don't set it
+SENTRY_DSN="SECRET-SENTRY-DSN" # Only if you want to enable Sentry, otherwise don't set it
 ```
 See [Dokku environment variables](http://dokku.viewdocs.io/dokku/configuration/environment-variables/) or [Heroku Config Vars](https://devcenter.heroku.com/articles/config-vars) for more details.
 

--- a/assets/src/index.jsx
+++ b/assets/src/index.jsx
@@ -6,9 +6,11 @@ import App from './components/App';
 
 import './index.css';
 
-Sentry.init({
-  dsn: 'https://9c31d56d5fab41ce9a199af00c3e1eb2@sentry.io/1406532',
-});
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+  });
+}
 
 ReactDOM.render(
   <ErrorBoundary>


### PR DESCRIPTION
Now only environments that have `process.env.SENTRY_DSN` defined will have sentry reports.

Closes #141 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/143)
<!-- Reviewable:end -->
