### PR TITLE
Remove waitlist toggle, enabling it permanently

### DIFF
--- a/assets/src/components/books/Book.jsx
+++ b/assets/src/components/books/Book.jsx
@@ -24,7 +24,6 @@ import {
   OTHERS_ARE_WAITING_STATUS,
 } from '../../utils/constants';
 import { BookPropType } from '../../utils/propTypes';
-import { isWaitlistFeatureActive } from '../../utils/toggles';
 import UserContext from '../UserContext';
 
 import './Book.css';
@@ -61,8 +60,6 @@ export default class Book extends Component {
   }
 
   async borrow() {
-    if (!isWaitlistFeatureActive()) return this.performAction(borrowBook, 'Borrow');
-
     const { book } = this.props;
     const { status } = await checkWaitlist(book);
     if (status !== OTHERS_ARE_WAITING_STATUS) {
@@ -81,11 +78,9 @@ export default class Book extends Component {
       case RETURN_BOOK_ACTION:
         return <Button color={color} onClick={() => this.performAction(returnBook, 'Return')}>Return</Button>;
       case JOIN_WAITLIST_BOOK_ACTION:
-        return isWaitlistFeatureActive()
-          && <Button color={color} onClick={() => this.performAction(joinWaitlist, 'JoinWaitlist')}>Join the waitlist</Button>;
+        return <Button color={color} onClick={() => this.performAction(joinWaitlist, 'JoinWaitlist')}>Join the waitlist</Button>;
       case LEAVE_WAITLIST_BOOK_ACTION:
-        return isWaitlistFeatureActive()
-          && <Button color={color} onClick={() => this.performAction(leaveWaitlist, 'LeaveWaitlist')}>Leave the waitlist</Button>;
+        return <Button color={color} onClick={() => this.performAction(leaveWaitlist, 'LeaveWaitlist')}>Leave the waitlist</Button>;
       default:
         return null;
     }

--- a/assets/src/components/mybooks/MyBooks.jsx
+++ b/assets/src/components/mybooks/MyBooks.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getMyBooks, getWaitlistBooks } from '../../services/BookService';
 import BookListLoader from '../books/BookListLoader';
-import { isWaitlistFeatureActive } from '../../utils/toggles';
 
 import './MyBooks.css';
 
@@ -15,14 +14,12 @@ const MyBooks = () => (
       />
     </PageSection>
 
-    {isWaitlistFeatureActive() && (
-      <PageSection title="On my wait list">
-        <BookListLoader
-          source={getWaitlistBooks}
-          noBooksMessage="To add a book to your wait list, click &ldquo;Join the waitlist&rdquo; on a book that is not available."
-        />
-      </PageSection>
-    )}
+    <PageSection title="On my wait list">
+      <BookListLoader
+        source={getWaitlistBooks}
+        noBooksMessage="To add a book to your wait list, click &ldquo;Join the waitlist&rdquo; on a book that is not available."
+      />
+    </PageSection>
   </div>
 );
 

--- a/assets/src/components/mybooks/MyBooks.test.jsx
+++ b/assets/src/components/mybooks/MyBooks.test.jsx
@@ -7,9 +7,6 @@ import { getMyBooks, getWaitlistBooks } from '../../services/BookService';
 import { someBookWithACopyFromMe } from '../../../test/booksHelper';
 
 jest.mock('../../services/BookService');
-jest.mock('../../utils/toggles', () => ({
-  isWaitlistFeatureActive: () => true,
-}));
 
 describe('MyBooks', () => {
   const books = [someBookWithACopyFromMe()];

--- a/assets/src/utils/toggles.js
+++ b/assets/src/utils/toggles.js
@@ -10,9 +10,6 @@ export const isToggleOn = (toggle) => {
   return isActive(localStorage.getItem(toggleKey));
 };
 
-export const isWaitlistFeatureActive = () => isToggleOn('waitlist');
-
 export default {
   isToggleOn,
-  isWaitlistFeatureActive,
 };


### PR DESCRIPTION
As the MVP milestone of waitlist was finished, we need to remove the toggle to make the functionality public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/168)
<!-- Reviewable:end -->
