### PR TITLE
Switch to dark mode automatically

### DIFF
--- a/assets/src/services/UserPreferences.js
+++ b/assets/src/services/UserPreferences.js
@@ -8,7 +8,19 @@ export const clearRegion = () => {
   localStorage.removeItem('region');
 };
 
-export const getDefaultTheme = () => localStorage.getItem('theme') || 'light';
+export const getDefaultTheme = () => {
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme) {
+    return storedTheme;
+  }
+
+  const prefersDarkMatch = '(prefers-color-scheme: dark)';
+  if (window.matchMedia && window.matchMedia(prefersDarkMatch).matches) {
+    return 'dark';
+  }
+
+  return 'light';
+};
 
 export const setDefaultTheme = (theme) => {
   localStorage.setItem('theme', theme);


### PR DESCRIPTION
Closes #145 

It uses window.matchMedia('prefers-color-scheme: dark') which should work both on browser and OS level.

Following the issue's acceptance criteria

1. first it checks for a setting on localStorage
2. then browser/OS dark mode setting
3. and finally it defaults to 'light'.

Demo: https://imgur.com/p04HfJI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/183)
<!-- Reviewable:end -->
