### PR TITLE
Update cffi and psycopg2 versions due to incompatibility w/ python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 asn1crypto==0.24.0
 astroid==1.6.0
 certifi==2018.1.18
-cffi==1.11.5
+cffi==1.14.2
 chardet==3.0.4
 coverage==4.5.1
 cryptography==2.5
@@ -24,7 +24,7 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 packaging==16.8
 Paste==2.0.3
-psycopg2==2.7.3.2
+psycopg2==2.8.6
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodomex==3.4.7


### PR DESCRIPTION
_[No issues associated]_

I was having some issues related to incompatibilities between the cffi and psycopg2 lib with python version while installing the requirements needed.

One of the problems was related to [this](https://github.com/psycopg/psycopg2/commit/c929f200484f5a2355edf769aaaee1e036129fd8) issue that was fixed into a most recent version of psycopg2

The same happened to the _cffi_ lib, which I also had to update to a most recent version

After doing those stuff, I was able to install the requirements :tada:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ayr-ton/kamu/184)
<!-- Reviewable:end -->
